### PR TITLE
adding compare_at_price to Variant shopify type

### DIFF
--- a/@types/shopify.d.ts
+++ b/@types/shopify.d.ts
@@ -269,7 +269,8 @@ declare namespace Shopify {
   }
 
   interface Variant {
-    available?: boolean, // only available via JS
+    available?: boolean, // only available via JS,
+    compare_at_price: number | string,
     featured_image: ProductImage | null,
     id: number,
     image_id: number,


### PR DESCRIPTION
added compare_at_price to Variant type so we can use it to display original prices.