### PR TITLE
add image_src property for Shopify LineItem

### DIFF
--- a/@types/shopify.d.ts
+++ b/@types/shopify.d.ts
@@ -163,6 +163,7 @@ declare namespace Shopify {
     discount_allocations: any[]
     admin_graphql_api_id: string
     tax_lines: TaxLine[]
+    image_src: string
   }
 
   interface Location {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@types/subscriptions-api",
-  "version": "1.0.5",
+  "version": "1.1.2",
   "description": "The Typescript types for subscription-api",
   "author": "Ethan Jon",
   "license": "UNLICENSED",


### PR DESCRIPTION
also, bumped to version to 1.1.2 to be in parity with new release branch