### PR TITLE
feat!: publish @launched-la/subscriptions-api-types to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: publish package to npm
+name: publish package to GitHub Packages
 
 on:
   push:
@@ -7,6 +7,13 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -18,8 +25,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Configure GitHub Packages auth
+        run: |
+          cat > .npmrc <<'EOF'
+          //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+          EOF
+
       - name: Semantic release
-        run: npx semantic-release@20.0.2 -b $GITHUB_REF_NAME -p @semantic-release/commit-analyzer -p @semantic-release/github -p @semantic-release/release-notes-generator -p @semantic-release/npm
+        run: npx -p semantic-release@20.0.2 -p @semantic-release/exec@6.0.3 -- semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,117 @@
+# subscriptions-api-types
+
+TypeScript types for the Launched LA subscription API.
+
+## What changed in 2.0.0
+
+This package moved from the public npm registry to **GitHub Packages**, hosted under the `launched-la` org. The scope also changed from `@launchedla` (no hyphen) to `@launched-la` (with hyphen) to satisfy GitHub Packages' requirement that the scope match the owning org's slug.
+
+| | Before 2.0.0 | 2.0.0+ |
+|---|---|---|
+| Package name | `@launchedla/subscriptions-api-types` | `@launched-la/subscriptions-api-types` |
+| Registry | `https://registry.npmjs.org` (public npm) | `https://npm.pkg.github.com` (GitHub Packages) |
+| Auth | `NPM_TOKEN` | `GITHUB_PACKAGES_TOKEN` (a GitHub PAT) |
+
+The old `@launchedla/subscriptions-api-types` on npm is frozen at its final version and being deprecated. No new versions will be published there.
+
+The exported types didn't change — this is a major version bump only because every consumer must update its `package.json`, `.npmrc`, imports, and CI secrets to keep working.
+
+## Consumer setup
+
+Each consumer repo needs to do the following once.
+
+### 1. Get a GitHub PAT for package reads
+
+Pick one:
+
+- **Classic PAT**: <https://github.com/settings/tokens> → "Generate new token (classic)" → check `read:packages`. Belongs to a maintainer or, preferably, a service account.
+- **Fine-grained token**: <https://github.com/settings/personal-access-tokens> scoped to the `launched-la` org with **Packages: Read-only**.
+
+Store it as `GITHUB_PACKAGES_TOKEN` (or any name — what matters is that your `.npmrc` references the same env var). One PAT can be reused across every `@launched-la` package, so if you already created one for `@launched-la/hb-shared`, the same token works here.
+
+For non-interactive shells (the kind that CI tooling and editor subprocesses launch), put the export in `~/.zshenv`, not just `~/.zshrc` — `.zshrc` is interactive-only.
+
+### 2. Update `.npmrc`
+
+If your repo already routes `@launched-la` to GitHub Packages for `hb-shared`, you're done — the scope-level route covers every `@launched-la/*` package. Otherwise add to your `.npmrc`:
+
+```
+@launched-la:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}
+```
+
+The `@launched-la:registry=...` line routes only the `@launched-la` scope to GitHub Packages — anything else still resolves from public npm.
+
+### 3. Update `package.json`
+
+Find every `"@launchedla/subscriptions-api-types": "^x.y.z"` and change it to `"@launched-la/subscriptions-api-types": "^2.0.0"` (or whatever the current major is).
+
+In monorepos this may be in multiple files (`apps/*/package.json`, `packages/*/package.json`).
+
+### 4. Update imports
+
+Codebase-wide find/replace:
+
+```
+@launchedla/subscriptions-api-types  →  @launched-la/subscriptions-api-types
+```
+
+Tests included.
+
+### 5. Reinstall
+
+Using the consumer's package manager:
+
+```
+pnpm install     # website
+yarn install     # meatball, cs-app, cloud-party
+npm install      # subscriptions-api
+```
+
+Commit the updated lockfile.
+
+### 6. Add the token to deploy targets
+
+Wherever the consumer runs `npm install` / `yarn install` / `pnpm install`, the env var (defaulting to `GITHUB_PACKAGES_TOKEN`) must be set:
+
+- **Vercel**: project Settings → Environment Variables.
+- **Render.com**: service env vars.
+- **AWS Elastic Beanstalk**: `.ebextensions` env config or EB console.
+- **GitHub Actions** (e.g. CI workflows in the consumer repo): add as a repo secret and expose under the env-var name your `.npmrc` interpolates. **Note**: GitHub forbids secret names that start with `GITHUB_`, so the secret has to be named something else (e.g. `GH_PACKAGES_TOKEN`) and aliased in the workflow's `env:` block to `GITHUB_PACKAGES_TOKEN`.
+- **Local development**: add to your shell profile (`~/.zshenv` for zsh so non-interactive shells see it).
+
+### 7. Verify
+
+- Repo builds: `pnpm build` / `yarn build` / `npm run build`.
+- Lint and typecheck pass per the workspace's task-completion convention.
+- App boots locally and code paths that import types from this package compile cleanly.
+- Deploy to staging; watch for `MODULE_NOT_FOUND` errors.
+
+## Install (after setup)
+
+```
+npm i -D @launched-la/subscriptions-api-types
+# or yarn add -D / pnpm add -D
+```
+
+Then:
+
+```ts
+import type { Shopify } from '@launched-la/subscriptions-api-types'
+import type { CreateItemParams } from '@launched-la/subscriptions-api-types/types/shopify'
+```
+
+## To develop
+
+Edit `.ts` files in `src/`. The published artifact is type declarations only (`types/`); `prepack` runs `tsc` to regenerate them. No runtime code ships.
+
 ## Semantic Release
 
-This repository uses Semantic Release to publish its package to npm via GitHub Actions, do not manually publish to the package registry.
+This repo uses semantic-release configured in [`release.config.js`](./release.config.js) and run by [`.github/workflows/publish.yml`](./.github/workflows/publish.yml). Every push to `master` runs the workflow, and releases are decided by [conventional-commit](https://github.com/semantic-release/semantic-release#how-does-it-work) prefixes:
 
-To indicate to Semantic Release that a commit represents a fix, feature, or breaking update, use Semantic Release's commit message format: https://github.com/semantic-release/semantic-release#how-does-it-work
+- `fix: …` → patch bump
+- `feat: …` → minor bump
+- `feat!: …` or a `BREAKING CHANGE:` line in the body → major bump
+- Anything else (including merge-commit subjects like `Merge pull request #N…`) → no release
+
+Because PRs merge with merge commits (not squash) here, the prefix must appear on **at least one commit inside the feature branch** — the merge-commit subject itself doesn't qualify. Don't manually publish.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,16 @@
 {
-  "name": "@launchedla/subscriptions-api-types",
+  "name": "@launched-la/subscriptions-api-types",
   "version": "0.0.0",
   "description": "The Typescript types for subscription-api",
   "author": "Ethan Jon",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launched-la/subscriptions-api-types.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "exports": {
     ".": {
       "types": "./types/index.d.ts"

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  branches: ['master'],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    ['@semantic-release/npm', { npmPublish: false }],
+    [
+      '@semantic-release/exec',
+      {
+        publishCmd: 'npm publish',
+      },
+    ],
+    '@semantic-release/github',
+  ],
+};


### PR DESCRIPTION
## Summary

Same playbook as [\`hb-shared\` v2.0.0](https://github.com/launched-la/hb-shared/releases/tag/v2.0.0) — moves this package off the public npm registry to GitHub Packages, hosted under the \`launched-la\` org.

- Renames \`@launchedla/subscriptions-api-types\` → \`@launched-la/subscriptions-api-types\` to satisfy GitHub Packages' scope-must-match-org rule.
- Adds \`publishConfig.registry\` and a top-level \`repository\` field in \`package.json\`.
- Extracts semantic-release config into [\`release.config.js\`](./release.config.js); \`@semantic-release/npm\` runs with \`npmPublish: false\` (still bumps version + builds tarball) and \`@semantic-release/exec\` runs the actual \`npm publish\` against GitHub Packages.
- Updates the publish workflow with \`permissions: packages: write\`, a workflow-scoped \`.npmrc\`, and drops \`NPM_TOKEN\` from env. \`GITHUB_TOKEN\` is auto-provided.
- README rewritten as a consumer migration guide.

## Why now

The \`NPM_TOKEN\` for \`@launchedla\` scope has been flaky — \`@launched-la/hb-shared\` was migrated for the same reason. The website's a11y CI just hit a 404 trying to fetch this package because the repo-secret \`NPM_TOKEN\` doesn't have read access. Moving off npm closes that flake category permanently.

## Consumer impact (per workspace audit)

| Repo | package.json refs | Source imports |
|---|---|---|
| \`subscriptions-api\` | 1 | 69 files |
| \`meatball\` | 1 | 107 files |
| \`cs-app\` | 1 | 12 files |
| \`website\` | 1 | 7 files |
| \`cloud-party\` | — | 0 |

Each consumer needs the same migration steps as the hb-shared rollout: \`.npmrc\` scope route, \`package.json\` dep rename, codebase-wide import find/replace, \`GITHUB_PACKAGES_TOKEN\` in deploy envs.

## Test plan

- [ ] Verify Actions run on master is green after merge
- [ ] Confirm \`@launched-la/subscriptions-api-types@2.0.0\` appears at https://github.com/orgs/launched-la/packages
- [ ] Confirm a GitHub Release for \`v2.0.0\` is created with auto-generated notes
- [ ] Run a fresh \`pnpm install\` in the website repo (Phase 2 PR will land separately) to confirm the published package is fetchable

🤖 Generated with [Claude Code](https://claude.com/claude-code)